### PR TITLE
config math font A-Z/a-z for kapital.cls

### DIFF
--- a/tex/kapital.cls
+++ b/tex/kapital.cls
@@ -71,6 +71,22 @@
   BoldItalicFont = *-bolditalic
 ]
 
+\setmathfont{STIX2Math}[% A-Z
+  Path = fonts/ ,
+  Extension = .otf ,
+  StylisticSet=01 ,
+  range={"00041-"0005A}
+  % Scale = 1.0 
+]
+
+\setmathfont{STIX2Math}[% a-z
+  Path = fonts/ ,
+  Extension = .otf ,
+  StylisticSet=01 ,
+  range = {"00061-"0007A}
+  % Scale = 1.0 
+]
+
 %% typography
 \usepackage{microtype}
 \frenchspacing


### PR DESCRIPTION
STIX2Math только под латинские буквы в мат. формулах.
Под два диапазона: A-Z и a-z, без цифр и спецсимволов.
Иначе берёт шрифт computer modern, так как в основном шрифте не находит.