### PR TITLE
2 font A-Z/a-z and symbols for kapital.cls

### DIFF
--- a/tex/kapital.cls
+++ b/tex/kapital.cls
@@ -17,29 +17,40 @@
 % \setotherlanguage{french}
 
 % fonts
-\setmainfont{serif}[
-  Path = fonts/ ,
-  Extension = .ttf ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic
+\setmainfont{PTF55F}[
+	Path = fonts/paratype/ ,
+    Extension = .ttf ,
+    UprightFont = PTF55F ,
+    BoldFont = PTF75F ,
+    ItalicFont = PTF56F ,
+    BoldItalicFont = PTF76F
 ]
-\setsansfont{sans}[
-  Path = fonts/ ,
-  Extension = .ttf ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic
+
+\setsansfont{PTS55F}[
+	Path = fonts/paratype/ ,
+    Extension = .ttf ,
+    UprightFont = PTS55F ,
+    BoldFont = PTS75F ,
+    ItalicFont = PTS56F ,
+    BoldItalicFont = PTS76F
 ]
-\newfontfamily{\greekfont}{STIX2Text}[
-  Path = fonts/ ,
-  Script=Greek,
-  Extension=.otf,
-  UprightFont=*-Regular,
-  ItalicFont=*-Italic,
-  BoldFont=*-Bold,
-  BoldItalicFont=*-BoldItalic,
-  Scale=MatchLowercase,
+
+\setmonofont{PTM55F}[
+	Path = fonts/paratype/ ,
+    Extension = .ttf ,
+    UprightFont = PTM55F ,
+    BoldFont = PTM75F
+]
+
+\newfontfamily{\greekfont}{STIX2Text-Regular}[
+  Path = fonts/stix-fonts/ ,
+  Script = Greek ,
+  Extension = .otf ,
+  UprightFont = STIX2Text-Regular ,
+  ItalicFont = STIX2Text-Italic ,
+  BoldFont = STIX2Text-Bold ,
+  BoldItalicFont = STIX2Text-BoldItalic ,
+  Scale = MatchLowercase
 ]
 
 % titles
@@ -64,13 +75,39 @@
 \RequirePackage{amsmath}
 
 \usepackage{unicode-math}
-\setmathfont{serif}[
-  Path = fonts/ ,
+\setmathfont{PTF55F}[
+  Path = fonts/paratype/ ,
   Extension = .ttf ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic
+  UprightFont = PTF55F ,
+  BoldFont = PTF75F ,
+  ItalicFont = PTF56F ,
+  BoldItalicFont = PTF76F 
 ]
+
+\setmathfont{STIX2Math}[% A-Z
+  Path = fonts/stix-fonts/ ,
+  Extension = .otf ,
+  StylisticSet=01 ,
+  Scale = MatchLowercase ,
+  range = {"00041-"0005A, "1D400-"1D419, "1D434-"1D44D, "1D468-"1D481, "1D49C-"1D4B5, "1D4D0-"1D4E9, "1D5A0-"1D5B9, "1D5D4-"1D5ED, "1D608-"1D621, "1D63C-"1D655, "1D538-"1D551, "1D504-"1D51D, "1D56C-"1D585, "1D670-"1D689}
+]
+
+\setmathfont{STIX2Math}[% a-z
+  Path = fonts/stix-fonts/ ,
+  Extension = .otf ,
+  StylisticSet=01 ,
+  Scale = MatchLowercase ,
+  range = {"00061-"0007A, "1D41A-"1D433, "1D44E-"1D467, "1D482-"1D49B, "1D4B6-"1D4CF, "1D4EA-"1D503, "1D5BA-"1D5D3, "1D5EE-"1D607, "1D622-"1D63B, "1D656-"1D66F, "1D552-"1D56B, "1D51E-"1D537, "1D586-"1D59F, "1D68A-"1D6A3}
+]
+
+\setmathfont{STIX2Math}[% math symbols % двоеточие, производная, также могут быть и лишние
+  Path = fonts/stix-fonts/ ,
+  Extension = .otf ,
+  StylisticSet=01 ,
+  Scale = MatchLowercase ,
+  range = {"0003A, "0002B, "00027, "00060, "000B4, "0002B9, "0002BA, "0002BB, "0002BC, "0002BD, "0002CA, "0002CB, "00030D, "000384, "0002032, "0002035, "0002236    } 
+]
+
 
 %% Alllow cyrilic letters in math
 \DeclareSymbolFont{cyrletters}{\encodingdefault}{\familydefault}{m}{it}

--- a/tex/kapital.cls
+++ b/tex/kapital.cls
@@ -74,6 +74,7 @@
 \RequirePackage{xfrac}
 \RequirePackage{amsmath}
 
+\DeclareSymbolFont{letters}{\encodingdefault}{\rmdefault}{m}{it}
 \usepackage{unicode-math}
 \setmathfont{PTF55F}[
   Path = fonts/paratype/ ,


### PR DESCRIPTION
Уточнены полные имена шрифтов, решило проблему компиляции в LuaLaTeX с footnote.
STIX2Math настроен только под латинские буквы и некоторые спецсимволы в мат. формулах.
Под два диапазона: A-Z и a-z, без цифр, минимум спецсимволов, для всех начертаний.
Иначе берёт шрифт computer modern, так как в основном шрифте не находит.